### PR TITLE
update cert-gen.sh script for openssl versions after 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,7 @@ Aiming for a clear example in the common-design-stack repo - will update when th
 Copy the contents of `new-site-template` to an `env/local` directory in the
 stack repo. Follow the instructions in `setup-notes.md`, making changes to
 anything that's not clear.
+
+## 502 'too big header' error
+
+See `etc/nginx/vhost.d/README.md`

--- a/cert-gen.sh
+++ b/cert-gen.sh
@@ -33,10 +33,8 @@ docker exec -it local-reverse-proxy bash -c "openssl req \
   -newkey rsa:2048 \
   -keyout /etc/nginx/certs/${SITE_URL}.key \
   -out /etc/nginx/certs/${SITE_URL}.crt \
-  -reqexts SAN \
-  -extensions SAN \
   -subj '/C=US/ST=NY/L=New York/O=OCHA/OU=DS/CN=${SITE_URL}' \
-  -config <(cat /etc/ssl/openssl.cnf; printf '\n[SAN]\nsubjectAltName=DNS:${SITE_URL}')"
+  -addext 'subjectAltName=DNS:${SITE_URL}'"
 
 # Restart the proxy container to ensure it uses the certificate.
 docker-compose restart


### PR DESCRIPTION
Fix discovered via https://security.stackexchange.com/questions/74345/provide-subjectaltname-to-openssl-directly-on-the-command-line and https://github.com/openssl/openssl/commit/bfa470a4f64313651a35571883e235d3335054eb

Note this means openssl must be up-to-date-ish.